### PR TITLE
Fix: Java no_proxy var host separator must be escaped

### DIFF
--- a/templates/bambooagent.service.j2
+++ b/templates/bambooagent.service.j2
@@ -7,7 +7,7 @@ Environment=PATH=/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin{% if bam
 
 Environment=JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF-8
 {%if http_proxy is defined and https_proxy is defined %}
-Environment="JAVA_OPTS=-Dhttp.nonProxyHosts={{ http_proxy.no_proxy | default([]) | join("|") }} -Dhttp.proxyHost={{ http_proxy.host | default('') }} -Dhttp.proxyPort={{ http_proxy.port | default('') }} -Dhttps.proxyHost={{ https_proxy.host | default('') }} -Dhttps.proxyPort={{ https_proxy.port | default('') }} -Dhttp.proxyUser={{ http_proxy.user | default('') }} -Dhttp.proxyPassword={{ http_proxy.password | default('') }}"
+Environment="JAVA_OPTS=-Dhttp.nonProxyHosts={{ http_proxy.no_proxy | default([]) | join("\|") }} -Dhttp.proxyHost={{ http_proxy.host | default('') }} -Dhttp.proxyPort={{ http_proxy.port | default('') }} -Dhttps.proxyHost={{ https_proxy.host | default('') }} -Dhttps.proxyPort={{ https_proxy.port | default('') }} -Dhttp.proxyUser={{ http_proxy.user | default('') }} -Dhttp.proxyPassword={{ http_proxy.password | default('') }}"
 Environment=http_proxy=http://{% if http_proxy.user is defined and http_proxy.password is defined %}{{ http_proxy.user }}:{{ http_proxy.password }}@{% endif %}{{ http_proxy.host }}:{{ http_proxy.port }}
 Environment=https_proxy=http://{% if http_proxy.user is defined and http_proxy.password is defined %}{{ http_proxy.user }}:{{ http_proxy.password }}@{% endif %}{{ https_proxy.host }}:{{ https_proxy.port }}
 Environment=no_proxy={{ http_proxy.no_proxy | default([]) | join(",") }}


### PR DESCRIPTION
Signed-off-by: Daniel Mohr <daniel.mohr@supercrunch.io>